### PR TITLE
add detail on types of talks

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,10 +12,10 @@ postal-code:
 
 # Welcome to OWASP Bristol Chapter 
 
-The OWASP Bristol Chapter  is  run by [Katy Anton](mailto:katy.anton@owasp.org) and [Craig Francis](mailto:craig.francis@owasp.org) .
+The OWASP Bristol Chapter is run by [Katy Anton][katy], [Craig Francis][craig] and [Jon Gadsden][jon].
 
-We are  a bunch of friendly people interested in Application Security, and as Software is all over these days, means we
-are interested in every flavour of security. 
+We are  a bunch of friendly people interested in Application Security,
+and as Software is all over these days this means we are interested in every flavour of security.
 
 ## Social media
 * Our meetings are scheduled on [Meetup](https://www.meetup.com/OWASP-Bristol/) 
@@ -69,4 +69,8 @@ Here is the list of organisations who have generously provided us with space for
 </td>
 </tr>
 </table>
+
+[katy]: mailto:katy.anton@owasp.org
+[craig]: mailto:craig.francis@owasp.org
+[jon]: mailto:jon.gadsden@owasp.org
 

--- a/index.md
+++ b/index.md
@@ -22,12 +22,22 @@ are interested in every flavour of security.
 * Chapter meetings promotion is primarily done on [Twitter](https://twitter.com/OWASPBristol)
 
 ## Speaking at OWASP Bristol Chapter Events
-Call For Speakers is open - if you would like to present a talk on Application Security at future OWASP Bristol Chapter
-events - please review and agree with the OWASP Speaker Agreement and send the proposed talk title, abstract and speaker
-bio to: [Katy Anton](mailto:katy.anton@owasp.org)  / <a rel="me" href="https://infosec.exchange/@katyanton">Katy Anton @Infosec Exchange</a>
+Call For Speakers is open - if you would like to present a talk on Application Security
+at future OWASP Bristol Chapter events - please review and agree with
+the OWASP [Speaker Agreement](https://owasp.org/www-policy/legal/speaker-agreement)
+and send the proposed talk title, abstract and speaker bio to:
+[Katy Anton](mailto:katy.anton@owasp.org)  / <a rel="me" href="https://infosec.exchange/@katyanton">Katy Anton @Infosec Exchange</a>
+
+All types of talks and presentations are welcome, such as:
+
+* Short / lightning talks, approximately 10 minutes on a specific subject
+* Longer talks between 30 and 45 minutes
+* Wider ranging presentation or tutorials up to an hour long
 
 ## Chapter Meetings
-Please see the [Meetup](https://www.meetup.com/owasp-bristol/) page for schedule and to register for meetings. 
+Please see the [Meetup](https://www.meetup.com/owasp-bristol/) page for the schedule
+and to register for meetings.
+Typically our meetings are held in the evening and last for a couple of hours.
 
 ### Check our Upcoming Meetup Events
 {% include chapter_events.html group=page.meetup-group %}

--- a/info.md
+++ b/info.md
@@ -12,6 +12,6 @@
 
 ### Code Repository
 * [Page Repo](https://github.com/OWASP/www-chapter-bristol-uk)
-* [Slides Repo](https://github.com/OWASP/www-chapter-london/tree/master/assets/slides)
+* [Slides Repo](https://github.com/OWASP/www-chapter-bristol-uk/tree/main/assets/slides)
 
 

--- a/info.md
+++ b/info.md
@@ -5,7 +5,7 @@
 * [Speaker Agreement](https://owasp.org/www-policy/legal/speaker-agreement)
 * [Code of Conduct](https://owasp.org/www-policy/operational/code-of-conduct)
 
-### Social Links
+### Contact Links
 * [Meetup](https://www.meetup.com/OWASP-Bristol/)
 * [Twitter](https://twitter.com/OWASPBristol)
 * [YouTube Bristol](https://www.youtube.com/channel/UC1lUjD1zM1gD2JkSa1rxMYQ)


### PR DESCRIPTION
**Summary** :  
This pull request adds some detail on what types of talks we would like to see
It also changes the slides link to the Bristol page rather than the London page

**Description for the changelog** :  
add detail on types of talks

**Other info** :