### PR TITLE
add slides for event 2023-06-15

### DIFF
--- a/tab_pastevents.md
+++ b/tab_pastevents.md
@@ -13,17 +13,23 @@ For the next scheduled events, pleave visit the [Meetup](https://www.meetup.com/
 
 Below is a list of the previous events details
 
+### 2023
+
+* [2023-06-15](https://www.meetup.com/owasp-bristol/events/290892060/):
+  * Talk 1: LLM and Application Security, Chris Wood
+  * Talk 2: An Introduction to scripting for Application Testers, Alex Archondakis - [slides](https://github.com/OWASP/www-chapter-bristol-uk/tree/main/assets/slides/2023/06-15-Scripting.pdf)
+
 ### 2020
 
 * [2020-02-27](https://www.meetup.com/owasp-bristol/events/268319030/):
-  * Talk 1: Damage Limitation, Craig Francis - [video](https://www.facebook.com/owaspBristol/videos/vb.100023289937843/639771026809223/), [slides](https://github.com/OWASP/www-chapter-bristol-uk/tree/main/assets/slides/2020/02-27-Damage-Limitation.pdf).
-  * Talk 2: Kerberos Authentication, Sadi Zane - [video](https://www.facebook.com/owaspBristol/videos/vb.100023289937843/639829846803341/).
+  * Talk 1: Damage Limitation, Craig Francis - [video](https://www.facebook.com/owaspBristol/videos/vb.100023289937843/639771026809223/), [slides](https://github.com/OWASP/www-chapter-bristol-uk/tree/main/assets/slides/2020/02-27-Damage-Limitation.pdf)
+  * Talk 2: Kerberos Authentication, Sadi Zane - [video](https://www.facebook.com/owaspBristol/videos/vb.100023289937843/639829846803341/)
 
 ### 2019
 
 * [2019-11-14](https://www.meetup.com/owasp-bristol/events/261525682/): "Containers and Threat Modelling"
-  * Talk 1: Least-privilege principle of container security, Ben Meier - [video](https://www.facebook.com/OWASPBristolChapter/videos/273762846884042/).
-  * Talk 2: OWASP Threat Dragon: Cupcake to the rescue, Jon Gadsden - [video](https://www.facebook.com/OWASPBristolChapter/videos/652333085173880/).
+  * Talk 1: Least-privilege principle of container security, Ben Meier - [video](https://www.facebook.com/OWASPBristolChapter/videos/273762846884042/)
+  * Talk 2: OWASP Threat Dragon: Cupcake to the rescue, Jon Gadsden - [video](https://www.facebook.com/OWASPBristolChapter/videos/652333085173880/)
 * [2019-09-12](https://www.meetup.com/owasp-bristol/events/261525677/): "Finding Security Vulnerabilities"
 * [2019-07-07](https://www.meetup.com/owasp-bristol/events/260281462/): "Internet Stalking and Exploits with Scratch"
 * [2019-06-06](https://www.meetup.com/owasp-bristol/events/261458168/): "HiTag2 Crypto"


### PR DESCRIPTION
**Summary** :  
renamed slide deck `2023-06-Alex-OWASP-Scripting.pdf` as `06-15-Scripting.pdf` because that fits in with our naming system from 2020, and uploaded to slides area
updated the tab for past events

**Description for the changelog** :  
add slides for event 2023-06-15

**Other info** :  
Note that the link checker is failing because the slides are not yet in the main branch slide area, so we are OK with this 

