### PR TITLE
update automation dependencies to use hashes

### DIFF
--- a/.github/workflows/housekeeping.yaml
+++ b/.github/workflows/housekeeping.yaml
@@ -5,7 +5,7 @@ on:
     - cron: '0 7 * * 6'
   workflow_dispatch:
 
-# for security reasons the github actions are pinned to specific release versions
+# for security reasons the github actions are pinned to specific SHAs
 jobs:
   chores:
     name: Tidy workflows

--- a/.github/workflows/housekeeping.yaml
+++ b/.github/workflows/housekeeping.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Delete stale workflow runs
-        uses: Mattraks/delete-workflow-runs@v2.1.0
+        uses: Mattraks/delete-workflow-runs@5bf9a1dac5c4d041c029f0a8370ddf0c5cb5aeb7
         with:
           token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -23,7 +23,7 @@ jobs:
           keep_minimum_runs: 25
 
       - name: Delete unused workflow runs
-        uses: otto-de/purge-deprecated-workflow-runs@v4.0.4
+        uses: otto-de/purge-deprecated-workflow-runs@f586d3fe7f959c38ca76a0030521dfa47946bce3
         with:
           token: ${{ github.token }}
 
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout markdown
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v2.8.0
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
         with:
           args: --verbose --no-progress --max-retries 1 '**/*.md' '*.md'
           fail: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,7 +5,7 @@ on:
       - main
   workflow_dispatch:
 
-# for security reasons the github actions are pinned to specific release versions
+# for security reasons the github actions are pinned to specific SHAs
 jobs:
   link_checker:
     name: Link checker
@@ -21,3 +21,18 @@ jobs:
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+  md_linter:
+    name: Lint markdown
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout markdown
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Lint markdown
+        uses: DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101
+        with:
+          config: '.markdownlint.yaml'
+          globs: |
+            **/*.md
+            *.md

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout markdown
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v2.8.0
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
         with:
           args: --verbose --no-progress --max-retries 1 '**/*.md' '*.md'
           fail: true

--- a/.github/workflows/validate-owasp-metadata.yaml
+++ b/.github/workflows/validate-owasp-metadata.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Validate metadata file
         uses: owasp/nest-schema/.github/actions/validate@011b47d59567ae7cfd246948c67503ba2f6cc15b

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -122,8 +122,8 @@ Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcem
 See the [FAQ][faq] for answers to common questions about this code of conduct,
 and translations are available of this [contributor covenant][translate].
 
-[cofc]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
-[diversity]: https://github.com/mozilla/diversity
-[faq]: https://www.contributor-covenant.org/faq
+[cofc]: https://www.contributor-covenant.org/version/2/0/code_of_conduct/
+[diversity]: https://github.com/mozilla/inclusion
+[faq]: https://www.contributor-covenant.org/faq/
 [homepage]: https://www.contributor-covenant.org
-[translate]: https://www.contributor-covenant.org/translations
+[translate]: https://www.contributor-covenant.org/translations/

--- a/index.md
+++ b/index.md
@@ -30,7 +30,7 @@ in promoting a more diverse software security community in the South West of Eng
 ## Chapter Meetings
 
 Typically our meetings are held in the evening and last for a couple of hours.
-View the schedule on the [events tab](https://owasp.org/www-chapter-bristol-uk/#div-events)
+View the scheduled [events][events-tab]
 for our next meeting and also for past meetings.
 
 To register for an event please visit our [Meetup][meetup] page.
@@ -54,25 +54,31 @@ that works to improve the security of software.
 All of our projects, tools, documents, forums, and chapters are free
 and open to anyone interested in improving application security.
 
-Everyone is welcome and encouraged to participate in our [Projects](/projects), [Local Chapters](/chapters),
-[Events](/events), [Online Groups][groups] and [Community Slack Channel][community].
+Everyone is welcome and encouraged to participate in our [Projects][projects], [Local Chapters][chapters],
+[Events][events], [Online Groups][groups] and [Community Slack Channel][community].
 We especially encourage diversity in all our initiatives.
 
 OWASP is a fantastic place to learn about application security, to network,
 and even to build your reputation as an expert.
-We also encourage you to be [become a member](/membership)
-or consider a [donation](/donate) to support our ongoing work.
+We also encourage you to be [become a member][membership]
+or consider a [donation][donate] to support our ongoing work.
 
 Chapters are led by local leaders in accordance with the [Chapter Leader Handbook][handbook].
 
+[chapters]: https://owasp.org/chapters/
 [community]: https://owasp.slack.com/
 [craig]: mailto:craig.francis@owasp.org
+[donate]: https://owasp.org/donate/
+[events]: https://owasp.org/events/
+[events-tab]: https://owasp.org/www-chapter-bristol-uk/#div-events
 [groups]: https://groups.google.com/a/owasp.com/
-[handbook]: /www-policy/rules-of-procedure/chapter-handbook
+[handbook]: https://policy.owasp.org/operational/chapters
 [jon]: mailto:jon.gadsden@owasp.org
 [linkedin]: https://www.linkedin.com/groups/8409530/
 [meetup]: https://www.meetup.com/owasp-bristol/
+[membership]: https://owasp.glueup.com/
+[projects]: https://owasp.org/projects/
 [slack]: https://owasp.slack.com/messages/CTRQ33DMK
-[speaker]: https://owasp.org/www-policy/legal/speaker-agreement
+[speaker]: https://policy.owasp.org/legal/speaker-agreement
 [witch]: https://www.witch.online/
 [youtube]: https://www.youtube.com/@OWASPBristol/featured

--- a/info.md
+++ b/info.md
@@ -1,10 +1,10 @@
 
 ### OWASP Information
 
-* [Become a Member](https://www.owasp.org/index.php/Membership)
-* [Chapter Policy](https://owasp.org/www-policy/operational/chapters)
-* [Speaker Agreement](https://owasp.org/www-policy/legal/speaker-agreement)
-* [Code of Conduct](https://owasp.org/www-policy/operational/code-of-conduct)
+* [Become a Member](https://owasp.glueup.com/)
+* [Chapter Policy](https://policy.owasp.org/operational/chapters)
+* [Speaker Agreement](https://policy.owasp.org/legal/speaker-agreement)
+* [Code of Conduct](https://policy.owasp.org/operational/code-of-conduct)
 
 ### Contact Links
 


### PR DESCRIPTION
**Summary** :  

update various dependencies in workflow actions
There was a recent high profile supply chain attack against `aquasecurity/trivy-action` which was successful.
therefore github actions need to be pinned to digests rather than versions

**Description for the changelog**:  

update automation dependencies to use digests

**Other info** :  

Closes #53 
